### PR TITLE
Fix build by adding missing export statements

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 import { NativeModules, Platform } from 'react-native';
 import { Context } from './context';
+export { Outcome, Context } from './context';
+export type { OutcomeMetadata } from './context';
 
 const LINKING_ERROR =
   `The package 'react-native-context-sdk' doesn't seem to be linked. Make sure: \n\n` +


### PR DESCRIPTION
## Description

These classes and types are being exported in the `context.tsx`, but they were not being re-exported from the `index.tsx`, causing failure when trying to call functions that require these types (e.g. `optimize`) or when logging outcomes, etc.