### PR TITLE
chore: Update to ContextSDK 4.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-context-sdk",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-context-sdk",
-      "version": "4.7.1",
+      "version": "4.7.2",
       "workspaces": [
         "example"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-context-sdk",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "ContextSDK for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-context-sdk",
-  "version": "4.7.2",
+  "version": "4.7.5",
   "description": "ContextSDK for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-context-sdk.podspec
+++ b/react-native-context-sdk.podspec
@@ -9,13 +9,19 @@ Pod::Spec.new do |s|
   s.summary      = package["description"]
   s.homepage     = package["homepage"]
   s.authors      = package["author"]
-
   s.platforms    = { :ios => '14.0' }
-  s.source       = { :git => "https://github.com/context-sdk/react-native", :tag => "#{s.version}" }
-
+  s.source       = { :git => "https://github.com/context-sdk/react-native", :tag => s.version }
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency("ContextSDK", package["version"])
+  # A map used to map the React Native version to the compatible Context SDK version, only when the these versions are not the same.
+  version_mapping = {
+    "4.7.2" => "4.7.0",
+    "4.7.3" => "4.7.0",
+    "4.7.4" => "4.7.0",
+    "4.7.5" => "4.7.1",
+  }
+  mapped_version = version_mapping[s.version] || s.version
+  s.dependency("ContextSDK", mapped_version)
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
@@ -37,7 +43,7 @@ Pod::Spec.new do |s|
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"
-    
+
    end
-  end    
+  end
 end


### PR DESCRIPTION
## Description

This PR applies the fix present in https://github.com/context-sdk/react-native/pull/18 and bumps the version based on v4.7.1 of the ContextSDK Swift SDK.

