### PR TITLE
chore: Update to ContextSDK `4.8.1-alpha.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-context-sdk",
-  "version": "4.8.0",
+  "version": "4.8.0+1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-context-sdk",
-      "version": "4.8.0",
+      "version": "4.8.0+1",
       "workspaces": [
         "example"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-context-sdk",
-  "version": "4.8.0+1",
+  "version": "4.8.1-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-context-sdk",
-      "version": "4.8.0+1",
+      "version": "4.8.1-alpha.2",
       "workspaces": [
         "example"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-context-sdk",
-  "version": "4.8.0+1",
+  "version": "4.8.1-alpha.1",
   "description": "ContextSDK for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-context-sdk",
-  "version": "4.8.0",
+  "version": "4.8.0+1",
   "description": "ContextSDK for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-context-sdk",
-  "version": "4.8.1-alpha.1",
+  "version": "4.8.1-alpha.2",
   "description": "ContextSDK for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-context-sdk.podspec
+++ b/react-native-context-sdk.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
     "4.7.3" => "4.7.0",
     "4.7.4" => "4.7.0",
     "4.7.5" => "4.7.1",
+    "4.8.0+1" => "4.8.0",
   }
   mapped_version = version_mapping[s.version] || s.version
   s.dependency("ContextSDK", mapped_version)

--- a/react-native-context-sdk.podspec
+++ b/react-native-context-sdk.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
     "4.7.3" => "4.7.0",
     "4.7.4" => "4.7.0",
     "4.7.5" => "4.7.1",
-    "4.8.0+1" => "4.8.0",
+    "4.8.1-alpha.1" => "4.8.0",
   }
   mapped_version = version_mapping[s.version] || s.version
   s.dependency("ContextSDK", mapped_version)

--- a/react-native-context-sdk.podspec
+++ b/react-native-context-sdk.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.homepage     = package["homepage"]
   s.authors      = package["author"]
   s.platforms    = { :ios => '14.0' }
-  s.source       = { :git => "https://github.com/context-sdk/react-native", :tag => s.version }
+  s.source       = { :git => "https://github.com/context-sdk/react-native", :tag => s.version.to_s }
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   # A map used to map the React Native version to the compatible Context SDK version, only when the these versions are not the same.
@@ -20,8 +20,9 @@ Pod::Spec.new do |s|
     "4.7.4" => "4.7.0",
     "4.7.5" => "4.7.1",
     "4.8.1-alpha.1" => "4.8.0",
+    "4.8.1-alpha.2" => "4.8.0",
   }
-  mapped_version = version_mapping[s.version] || s.version
+  mapped_version = version_mapping[s.version.to_s] || s.version.to_s
   s.dependency("ContextSDK", mapped_version)
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.


### PR DESCRIPTION
## Description

This PR applies the fix present in https://github.com/context-sdk/react-native/pull/18 and bumps the version based on v4.8.0 of the ContextSDK Swift SDK.
